### PR TITLE
Использование компонента Photo в Message. Фиксы css

### DIFF
--- a/app/Components/Message.css
+++ b/app/Components/Message.css
@@ -15,16 +15,12 @@ a{
   grid-template-columns: auto 1fr;
   grid-column-gap: 10px;
   align-items: center;
+  line-height: 1;
 }
 
 .post-head__img{
-  align-self: start;
-  margin-top: 5px;
+  display: flex;
   grid-row: 1 / 3;
-  max-width: 50px;
-  width: 100%;
-  border-radius: 50%;
-  cursor: pointer;
 }
 
 .post-head__name{
@@ -52,21 +48,11 @@ a{
   white-space: nowrap;
 }
 
-.post-attachments__img{
-  max-width: 100%;
-}
-
 /* In Message block */
-.message .post-head__date{
-  font-size: 12px;
-}
 .message .post-head__name{
   font-size: 13px;
 }
-.message .post-head__img{
-  width: 40px;
-  height: 40px;
-}
+
 .message .post-head__text{
   font-size: 13px;
   margin: 0;

--- a/app/Components/Message.js
+++ b/app/Components/Message.js
@@ -14,14 +14,17 @@
 define(
   'app/Components/Message.js', [
     'app/Components/Component.js',
+    'app/Components/photo/Photo.js',
     'css!app/Components/Message.css'
   ],
-  function (Component) {
+  function (Component, Photo) {
 
     return class Message extends Component {
 
       /**
        * Инициализация компонента
+       * @param {Array} posts - массив объектов
+       * @param {String} type - тип сообщения: message или post
        */
       constructor(posts, type = 'post') {
 
@@ -37,8 +40,8 @@ define(
        */
       render() {
         // Возвращение рендера
-          return `
-          <div class="block messages">
+        return `
+          <div class="messages">
             ${this.renderPosts()}
           </div>
           `;
@@ -46,13 +49,15 @@ define(
       /**
        * Рендер постов 
        */
-      renderPosts(){
+      renderPosts() {
         let posts = '';
         this.posts.forEach(post => {
           posts += `
               <div class="post ${this.type == 'message' ? 'message' : ''}">
                 <div class="post-head">
-                  <img class="block__img post-head__img" src="${post.avatar}" alt=""/>
+                  <div class="post-head__img">
+                    ${new Photo(post.avatar,'s')}
+                  </div>
                   <span class="post-head__name" title="${post.name}"><a href="#">${post.name}</a></span>
                   <span class="post-head__date" title="${post.date}">${post.date}</span>
                   <span class="post-head__text" title="${post.text}">${post.text}</span>
@@ -67,10 +72,10 @@ define(
        * При выборе типа "post" возможен
        * пендер прикрепленных файлов (фото)
        */
-      renderPostAttachments(post){
+      renderPostAttachments(post) {
         return `
         <div class="post-attachments">
-          ${post.img ? `<img class="block__img post-attachments__img" src="${post.img}" alt=""/>` : ''}
+          ${post.img ? new Photo(post.img, 'xl') : ''}
         </div>
         `;
       }

--- a/app/Controllers/UserPage.js
+++ b/app/Controllers/UserPage.js
@@ -53,13 +53,13 @@ define('app/Controllers/UserPage.js', [
             }]
 
             this.messagesData = [{
-                avatar:"assets/img/6_square.jpg",
+                avatar:"assets/img/7_square.jpg",
                 name:"Дэвид Грей",
                 date:"Вчера 16:10",
                 text:"Давно тебя не было в уличных гонках!",
             },
             {
-                avatar:"assets/img/7_square.jpg",
+                avatar:"assets/img/6_square.jpg",
                 name:"Мак ДеМарко",
                 date:"Вчера 16:10",
                 text:"Ты уже послушала мой новый альбом? Тебе понравится, обещаю.",
@@ -86,12 +86,16 @@ define('app/Controllers/UserPage.js', [
                         <aside>
                             ${new ProfileInfo(user)}
                             ${new ProfilePhotos()}
-                            ${new Message(this.postsData, 'post')}
+                            <div class="block">
+                                ${new Message(this.postsData, 'post')}
+                            </div>
                         </aside>
                         <div>
                             ${new Photo("assets/img/people-square.jpg",'l')}
                             ${new ProfileActions()}
-                            ${new Message(this.messagesData, 'message')}
+                            <div class="block">
+                                ${new Message(this.messagesData, 'message')}
+                            </div>
                         </div>
                     </section>
                 </div>


### PR DESCRIPTION
Вместо изображений теперь используется компонент Photo разных размеров
Белый фон для блоков больше не добавляется автоматически
Теперь так:
![image](https://user-images.githubusercontent.com/32700204/79331860-4b354d00-7f35-11ea-8a36-9f2bd5674aa1.png)

